### PR TITLE
v0.13.1: WiFi settings dialog + showcase fetch stagger

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.bpmct.trmnl_nook_simple_touch"
-    android:versionCode="130099"
-    android:versionName="0.13.0" >
+    android:versionCode="130100"
+    android:versionName="0.13.1" >
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/src/com/bpmct/trmnl_nook_simple_touch/DisplayActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/DisplayActivity.java
@@ -1,6 +1,8 @@
 package com.bpmct.trmnl_nook_simple_touch;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
@@ -1499,13 +1501,22 @@ public class DisplayActivity extends Activity {
         wifiBtn.setOnTouchListener(new View.OnTouchListener() {
             public boolean onTouch(View v, MotionEvent event) {
                 if (event.getAction() == MotionEvent.ACTION_UP) {
-                    Intent wifiIntent = new Intent();
-                    wifiIntent.setClassName("com.android.settings", "com.android.settings.wifi.Settings_Wifi_Settings");
-                    try {
-                        startActivity(wifiIntent);
-                    } catch (Throwable t2) {
-                        try { startActivity(new Intent(android.provider.Settings.ACTION_WIFI_SETTINGS)); } catch (Throwable t3) {}
-                    }
+                    new AlertDialog.Builder(DisplayActivity.this)
+                        .setTitle("Opening Wi-Fi Settings")
+                        .setMessage("After connecting, press the Home button on your NOOK to return to this app.")
+                        .setPositiveButton("Open Wi-Fi Settings", new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                Intent wifiIntent = new Intent();
+                                wifiIntent.setClassName("com.android.settings", "com.android.settings.wifi.Settings_Wifi_Settings");
+                                try {
+                                    startActivity(wifiIntent);
+                                } catch (Throwable t2) {
+                                    try { startActivity(new Intent(android.provider.Settings.ACTION_WIFI_SETTINGS)); } catch (Throwable t3) {}
+                                }
+                            }
+                        })
+                        .setNegativeButton("Cancel", null)
+                        .show();
                 }
                 return true;
             }

--- a/src/com/bpmct/trmnl_nook_simple_touch/DisplayActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/DisplayActivity.java
@@ -1503,7 +1503,7 @@ public class DisplayActivity extends Activity {
                 if (event.getAction() == MotionEvent.ACTION_UP) {
                     new AlertDialog.Builder(DisplayActivity.this)
                         .setTitle("Opening Wi-Fi Settings")
-                        .setMessage("After connecting, press the Home button on your NOOK to return to this app.")
+                        .setMessage("After connecting, press the Home button on the bottom of this device to return to this app.")
                         .setPositiveButton("Open Wi-Fi Settings", new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
                                 Intent wifiIntent = new Intent();

--- a/src/com/bpmct/trmnl_nook_simple_touch/SettingsActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/SettingsActivity.java
@@ -228,7 +228,7 @@ public class SettingsActivity extends Activity {
             public void onClick(View v) {
                 new AlertDialog.Builder(SettingsActivity.this)
                     .setTitle("Opening Wi-Fi Settings")
-                    .setMessage("After connecting, press the Home button on your NOOK to return to this app.")
+                    .setMessage("After connecting, press the Home button on the bottom of this device to return to this app.")
                     .setPositiveButton("Open Wi-Fi Settings", new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int which) {
                             Intent wifiIntent = new Intent();

--- a/src/com/bpmct/trmnl_nook_simple_touch/SettingsActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/SettingsActivity.java
@@ -1,6 +1,8 @@
 package com.bpmct.trmnl_nook_simple_touch;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.Gravity;
@@ -224,13 +226,22 @@ public class SettingsActivity extends Activity {
         Button wifiSettingsButton = createGreyButton("WiFi Settings");
         wifiSettingsButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                Intent wifiIntent = new Intent();
-                wifiIntent.setClassName("com.android.settings", "com.android.settings.wifi.Settings_Wifi_Settings");
-                try {
-                    startActivity(wifiIntent);
-                } catch (Throwable t) {
-                    startActivity(new Intent(android.provider.Settings.ACTION_WIFI_SETTINGS));
-                }
+                new AlertDialog.Builder(SettingsActivity.this)
+                    .setTitle("Opening Wi-Fi Settings")
+                    .setMessage("After connecting, press the Home button on your NOOK to return to this app.")
+                    .setPositiveButton("Open Wi-Fi Settings", new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            Intent wifiIntent = new Intent();
+                            wifiIntent.setClassName("com.android.settings", "com.android.settings.wifi.Settings_Wifi_Settings");
+                            try {
+                                startActivity(wifiIntent);
+                            } catch (Throwable t) {
+                                startActivity(new Intent(android.provider.Settings.ACTION_WIFI_SETTINGS));
+                            }
+                        }
+                    })
+                    .setNegativeButton("Cancel", null)
+                    .show();
             }
         });
         LinearLayout.LayoutParams wifiSettBtnParams = new LinearLayout.LayoutParams(

--- a/src/com/bpmct/trmnl_nook_simple_touch/ShowcaseActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/ShowcaseActivity.java
@@ -373,7 +373,7 @@ public class ShowcaseActivity extends Activity {
     private static final long WIFI_WARMUP_MS = 15 * 1000;
     private final android.os.Handler handler = new android.os.Handler();
 
-    private static final long CELL_FETCH_STAGGER_MS = 1500;
+    private static final long CELL_FETCH_STAGGER_MS = 8000;
 
     private void startFetchAll() {
         if (isConnected()) {
@@ -521,7 +521,14 @@ public class ShowcaseActivity extends Activity {
                 handler.post(new Runnable() {
                     public void run() {
                         hideNoWifiScreen();
-                        for (int i = 0; i < NUM_CELLS; i++) fetchCell(i);
+                        for (int i = 0; i < NUM_CELLS; i++) {
+                            final int cellIdx = i;
+                            handler.postDelayed(new Runnable() {
+                                public void run() {
+                                    if (isCellConfigured(ShowcaseActivity.this, cellIdx)) fetchCell(cellIdx);
+                                }
+                            }, cellIdx * CELL_FETCH_STAGGER_MS);
+                        }
                     }
                 });
             }

--- a/src/com/bpmct/trmnl_nook_simple_touch/ShowcaseActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/ShowcaseActivity.java
@@ -1,6 +1,8 @@
 package com.bpmct.trmnl_nook_simple_touch;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -469,13 +471,22 @@ public class ShowcaseActivity extends Activity {
         wifiBtn.setOnTouchListener(new View.OnTouchListener() {
             public boolean onTouch(View v, android.view.MotionEvent event) {
                 if (event.getAction() == android.view.MotionEvent.ACTION_UP) {
-                    try {
-                        Intent wi = new Intent();
-                        wi.setClassName("com.android.settings", "com.android.settings.wifi.Settings_Wifi_Settings");
-                        try { startActivity(wi); } catch (Throwable t2) {
-                            startActivity(new Intent(android.provider.Settings.ACTION_WIFI_SETTINGS));
-                        }
-                    } catch (Throwable t) {}
+                    new AlertDialog.Builder(ShowcaseActivity.this)
+                        .setTitle("Opening Wi-Fi Settings")
+                        .setMessage("After connecting, press the Home button on your NOOK to return to this app.")
+                        .setPositiveButton("Open Wi-Fi Settings", new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                try {
+                                    Intent wi = new Intent();
+                                    wi.setClassName("com.android.settings", "com.android.settings.wifi.Settings_Wifi_Settings");
+                                    try { startActivity(wi); } catch (Throwable t2) {
+                                        startActivity(new Intent(android.provider.Settings.ACTION_WIFI_SETTINGS));
+                                    }
+                                } catch (Throwable t) {}
+                            }
+                        })
+                        .setNegativeButton("Cancel", null)
+                        .show();
                 }
                 return true;
             }

--- a/src/com/bpmct/trmnl_nook_simple_touch/ShowcaseActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/ShowcaseActivity.java
@@ -473,7 +473,7 @@ public class ShowcaseActivity extends Activity {
                 if (event.getAction() == android.view.MotionEvent.ACTION_UP) {
                     new AlertDialog.Builder(ShowcaseActivity.this)
                         .setTitle("Opening Wi-Fi Settings")
-                        .setMessage("After connecting, press the Home button on your NOOK to return to this app.")
+                        .setMessage("After connecting, press the Home button on the bottom of this device to return to this app.")
                         .setPositiveButton("Open Wi-Fi Settings", new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
                                 try {


### PR DESCRIPTION
## Summary

Two small UX improvements on top of the existing showcase mode.

### Changes

- **WiFi settings — show dialog before launching** — instead of showing a post-return overlay (which cannot appear on top of another app), tapping "Wi-Fi Settings" now shows an `AlertDialog` with the message: *"After connecting, press the Home button on the bottom of this device to return to this app."* Applies in `SettingsActivity`, `DisplayActivity`, and `ShowcaseActivity`
- **Showcase fetch stagger** — cells were firing simultaneously (or with a 1.5s gap) causing 4 concurrent TLS handshakes on boot. Stagger increased to 8s between cells (t=0, t=8s, t=16s, t=24s). Also fixed the connectivity-restored path which was firing all 4 at once with no stagger at all