### PR TITLE
feat: skip 2×2 grid and go fullscreen when only cell 0 is configured

### DIFF
--- a/src/com/bpmct/trmnl_nook_simple_touch/DisplayActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/DisplayActivity.java
@@ -458,8 +458,19 @@ public class DisplayActivity extends Activity {
             showGiftModeScreen();
             return;
         } else if (!isShowcaseCell() && ApiPrefs.isShowcaseModeEnabled(this)) {
-            startActivity(new Intent(this, ShowcaseActivity.class));
-            finish();
+            if (ShowcaseActivity.isOnlyCell0Configured(this)) {
+                // Single cell configured — launch it fullscreen directly, skip the grid
+                Intent si = new Intent(this, DisplayActivity.class);
+                si.putExtra(EXTRA_SHOWCASE_API_ID,    ShowcaseActivity.getCellId(this, 0));
+                si.putExtra(EXTRA_SHOWCASE_API_TOKEN, ShowcaseActivity.getCellToken(this, 0));
+                si.putExtra(EXTRA_SHOWCASE_API_URL,   ShowcaseActivity.getCellApiUrl(this, 0));
+                si.putExtra(EXTRA_SHOWCASE_CELL,      0);
+                startActivity(si);
+                finish();
+            } else {
+                startActivity(new Intent(this, ShowcaseActivity.class));
+                finish();
+            }
             return;
         } else if (!isShowcaseCell() && ApiPrefs.isGiftModeEnabled(this)) {
             showGiftModeScreen();
@@ -525,8 +536,18 @@ public class DisplayActivity extends Activity {
             showGiftModeScreen();
             return;
         } else if (!isShowcaseCell() && ApiPrefs.isShowcaseModeEnabled(this)) {
-            startActivity(new Intent(this, ShowcaseActivity.class));
-            finish();
+            if (ShowcaseActivity.isOnlyCell0Configured(this)) {
+                Intent si = new Intent(this, DisplayActivity.class);
+                si.putExtra(EXTRA_SHOWCASE_API_ID,    ShowcaseActivity.getCellId(this, 0));
+                si.putExtra(EXTRA_SHOWCASE_API_TOKEN, ShowcaseActivity.getCellToken(this, 0));
+                si.putExtra(EXTRA_SHOWCASE_API_URL,   ShowcaseActivity.getCellApiUrl(this, 0));
+                si.putExtra(EXTRA_SHOWCASE_CELL,      0);
+                startActivity(si);
+                finish();
+            } else {
+                startActivity(new Intent(this, ShowcaseActivity.class));
+                finish();
+            }
             return;
         } else if (!isShowcaseCell() && ApiPrefs.isGiftModeEnabled(this)) {
             showGiftModeScreen();

--- a/src/com/bpmct/trmnl_nook_simple_touch/ShowcaseActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/ShowcaseActivity.java
@@ -50,6 +50,18 @@ public class ShowcaseActivity extends Activity {
         return token != null && token.length() > 0;
     }
 
+    /**
+     * Returns true if only cell 0 is configured and cells 1–3 are all unconfigured.
+     * In this case the app should skip the 2×2 grid and go straight to cell 0 fullscreen.
+     */
+    static boolean isOnlyCell0Configured(Context context) {
+        if (!isCellConfigured(context, 0)) return false;
+        for (int i = 1; i < NUM_CELLS; i++) {
+            if (isCellConfigured(context, i)) return false;
+        }
+        return true;
+    }
+
     private static final int APP_ROTATION_DEGREES = 90;
     static final int NUM_CELLS = 4;
     private static final int CELL_PADDING = 6;
@@ -132,6 +144,23 @@ public class ShowcaseActivity extends Activity {
                 ViewGroup.LayoutParams.FILL_PARENT));
 
         setContentView(appRotateLayout);
+
+        // If only cell 0 is configured, skip the grid and go fullscreen immediately
+        if (isOnlyCell0Configured(this)) {
+            Intent i = new Intent(this, DisplayActivity.class);
+            i.putExtra(DisplayActivity.EXTRA_SHOWCASE_API_ID,    getCellId(this, 0));
+            i.putExtra(DisplayActivity.EXTRA_SHOWCASE_API_TOKEN, getCellToken(this, 0));
+            i.putExtra(DisplayActivity.EXTRA_SHOWCASE_API_URL,   getCellApiUrl(this, 0));
+            i.putExtra(DisplayActivity.EXTRA_SHOWCASE_CELL,      0);
+            Bitmap cached = loadCachedBitmap(this, 0);
+            if (cached != null) {
+                java.io.File f = new java.io.File(getFilesDir(), CACHE_PREFIX + "0.png");
+                if (f.exists()) i.putExtra(DisplayActivity.EXTRA_SHOWCASE_PRELOAD_PATH, f.getAbsolutePath());
+            }
+            startActivity(i);
+            finish();
+            return;
+        }
 
         loadCachedBitmaps();
         if (!anyCacheExists()) startFetchAll();


### PR DESCRIPTION
When showcase mode is enabled but only cell 1 (index 0) is configured and cells 2–4 are all unconfigured, skip the 2×2 grid entirely and launch that single cell fullscreen in `DisplayActivity`.\n\n### Changes\n\n**`ShowcaseActivity.java`**\n- Add `isOnlyCell0Configured(Context)` static helper — returns `true` when cell 0 has a token and cells 1–3 do not\n- In `onCreate`, short-circuit to `DisplayActivity` (as a showcase cell) before building the grid if only cell 0 is configured\n\n**`DisplayActivity.java`**\n- In both `onCreate` and `onResume` showcase-mode branches, call `isOnlyCell0Configured` and launch `DisplayActivity` directly with cell 0 credentials instead of `ShowcaseActivity` when the condition is met\n- Existing 4-cell grid path is unchanged\n\nPaired with a change in [bpmct/nooks](https://github.com/bpmct/nooks) that relaxes the web UI validation so only cell 1 is required when setting up showcase mode.