### PR TITLE
feat: configurable WiFi connect timeout (follow-up to #45)

### DIFF
--- a/src/com/bpmct/trmnl_nook_simple_touch/ApiPrefs.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/ApiPrefs.java
@@ -23,6 +23,13 @@ public class ApiPrefs {
     private static final String KEY_SUPER_SLEEP = "super_sleep";
     private static final String KEY_SCREENSAVER_WRITTEN = "screensaver_written_once";
     private static final String KEY_SHOWCASE_MODE = "showcase_mode";
+    private static final String KEY_WIFI_CONNECT_TIMEOUT = "wifi_connect_timeout_seconds";
+    /** Default association timeout (seconds). Matches the historical CONNECTIVITY_MAX_WAIT_MS (5s). */
+    public static final int DEFAULT_WIFI_CONNECT_TIMEOUT_SECONDS = 5;
+    /** Clamp bounds so a bad value can't brick the wake cycle (too short = never connects,
+     *  too long = battery drain waiting on a dead network). */
+    public static final int MIN_WIFI_CONNECT_TIMEOUT_SECONDS = 5;
+    public static final int MAX_WIFI_CONNECT_TIMEOUT_SECONDS = 120;
     private static final String SCREENSAVER_PATH = "/media/screensavers/TRMNL/display.png";
 
     public static boolean hasCredentials(Context context) {
@@ -339,6 +346,29 @@ public class ApiPrefs {
     public static void setSuperSleep(Context context, boolean enabled) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit()
                 .putBoolean(KEY_SUPER_SLEEP, enabled).commit();
+    }
+
+    /**
+     * WiFi association timeout in seconds. This is how long the app waits for the
+     * network to come up after a wake before giving up and showing the no-WiFi
+     * screen. Some access points / busy 2.4GHz environments take longer than the
+     * 5s default to associate (see issue #44), so this is user-configurable.
+     * Returned value is clamped to [MIN, MAX]. Default is
+     * DEFAULT_WIFI_CONNECT_TIMEOUT_SECONDS (preserves prior behavior).
+     */
+    public static int getWifiConnectTimeoutSeconds(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        int seconds = prefs.getInt(KEY_WIFI_CONNECT_TIMEOUT, DEFAULT_WIFI_CONNECT_TIMEOUT_SECONDS);
+        if (seconds < MIN_WIFI_CONNECT_TIMEOUT_SECONDS) seconds = MIN_WIFI_CONNECT_TIMEOUT_SECONDS;
+        if (seconds > MAX_WIFI_CONNECT_TIMEOUT_SECONDS) seconds = MAX_WIFI_CONNECT_TIMEOUT_SECONDS;
+        return seconds;
+    }
+
+    public static void setWifiConnectTimeoutSeconds(Context context, int seconds) {
+        if (seconds < MIN_WIFI_CONNECT_TIMEOUT_SECONDS) seconds = MIN_WIFI_CONNECT_TIMEOUT_SECONDS;
+        if (seconds > MAX_WIFI_CONNECT_TIMEOUT_SECONDS) seconds = MAX_WIFI_CONNECT_TIMEOUT_SECONDS;
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit()
+                .putInt(KEY_WIFI_CONNECT_TIMEOUT, seconds).commit();
     }
 
     /** Whether the initial screensaver has been written to disk at least once. */

--- a/src/com/bpmct/trmnl_nook_simple_touch/DisplayActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/DisplayActivity.java
@@ -124,7 +124,6 @@ public class DisplayActivity extends Activity {
     private Runnable pendingConnectivityTimeoutRunnable;
     private Runnable pendingFetchWatchdogRunnable;
     private ApiFetchTask currentFetchTask;
-    private static final long CONNECTIVITY_MAX_WAIT_MS = 5 * 1000;
     /** Longer wait used when the WiFi radio is still powering on (cold enable after
      * sleep). On Android 2.1 the OMAP3 radio can take several seconds just to reach
      * ENABLED, before association + DHCP even begin, so 5s is not enough. */
@@ -645,7 +644,8 @@ public class DisplayActivity extends Activity {
         return true;
     }
 
-    /** Wait for network to come up, then start fetch. Starts as soon as connectivity appears; max wait CONNECTIVITY_MAX_WAIT_MS. */
+    /** Wait for network to come up, then start fetch. Starts as soon as connectivity appears;
+     *  max wait is ApiPrefs.getWifiConnectTimeoutSeconds() (configurable, default 5s). */
     private void waitForWifiThenFetch() {
         cancelConnectivityWait();
         if (isConnectedToNetwork(this)) {
@@ -660,10 +660,13 @@ public class DisplayActivity extends Activity {
         }
         final DisplayActivity a = this;
         WifiManager wm = (WifiManager) getSystemService(Context.WIFI_SERVICE);
+        // User-configurable association timeout (issue #44). Default preserves the
+        // historical 5s behavior; users on slow/busy APs can raise it.
+        long configuredWaitMs = ApiPrefs.getWifiConnectTimeoutSeconds(this) * 1000L;
         // Default association wait. When the radio is still powering on (just
         // requested ON during the wake path), use a longer window so we don't give
         // up before the radio even reaches ENABLED.
-        long associationWaitMs = CONNECTIVITY_MAX_WAIT_MS;
+        long associationWaitMs = configuredWaitMs;
         // WiFi radio handling. setWifiEnabled(true) is asynchronous: on wake we ask
         // the radio to turn on, then call this method almost immediately, so the
         // radio is usually still in WIFI_STATE_ENABLING here. Treating that as
@@ -682,8 +685,9 @@ public class DisplayActivity extends Activity {
             }
             if (wifiState == WifiManager.WIFI_STATE_ENABLING) {
                 // Radio is coming up from a cold start — give it room to finish
-                // enabling, associate, and obtain DHCP before we time out.
-                associationWaitMs = CONNECTIVITY_COLD_RADIO_WAIT_MS;
+                // enabling, associate, and obtain DHCP before we time out. Honor a
+                // longer user-configured timeout if set.
+                associationWaitMs = Math.max(configuredWaitMs, CONNECTIVITY_COLD_RADIO_WAIT_MS);
                 logD("wifi radio enabling — waiting for it to come up");
             } else if (wifiState == WifiManager.WIFI_STATE_DISABLED
                     || wifiState == WifiManager.WIFI_STATE_DISABLING
@@ -694,7 +698,7 @@ public class DisplayActivity extends Activity {
                 if (ApiPrefs.isAllowSleep(this)) {
                     try {
                         wm.setWifiEnabled(true);
-                        associationWaitMs = CONNECTIVITY_COLD_RADIO_WAIT_MS;
+                        associationWaitMs = Math.max(configuredWaitMs, CONNECTIVITY_COLD_RADIO_WAIT_MS);
                         logD("wifi radio off — turning it on and waiting for connection");
                     } catch (Throwable t) {
                         logW("wifi enable failed: " + t);
@@ -747,11 +751,12 @@ public class DisplayActivity extends Activity {
             return;
         }
         // Hard timeout — show no-wifi screen then schedule a retry so we don't get stuck.
+        final long waitMs = associationWaitMs;
         pendingConnectivityTimeoutRunnable = new Runnable() {
             @Override public void run() {
                 pendingConnectivityTimeoutRunnable = null;
                 if (!isConnectedToNetwork(a)) {
-                    logD("connectivity timeout (" + (CONNECTIVITY_MAX_WAIT_MS / 1000L) + "s) wifi=" + a.getWifiStateString() + " — showing no-wifi screen");
+                    logD("connectivity timeout (" + (waitMs / 1000L) + "s) wifi=" + a.getWifiStateString() + " — showing no-wifi screen");
                     cancelConnectivityWait();
                     if (attemptWifiRecovery("connectivity timeout")) {
                         return;
@@ -762,7 +767,6 @@ public class DisplayActivity extends Activity {
                 }
             }
         };
-        final long waitMs = associationWaitMs;
         refreshHandler.postDelayed(pendingConnectivityTimeoutRunnable, waitMs);
         logD("not connected — waiting up to " + (waitMs / 1000L) + "s for association");
     }

--- a/src/com/bpmct/trmnl_nook_simple_touch/SettingsActivity.java
+++ b/src/com/bpmct/trmnl_nook_simple_touch/SettingsActivity.java
@@ -15,6 +15,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
+import android.widget.EditText;
 import android.widget.ScrollView;
 import android.content.Intent;
 import android.net.ConnectivityManager;
@@ -36,6 +37,7 @@ public class SettingsActivity extends Activity {
     private CheckBox allowHttpCheck;
     private CheckBox allowSelfSignedCheck;
     private CheckBox autoDisableWifiCheck;
+    private EditText wifiTimeoutInput;
     private TextView wifiStatusView;
     private FrameLayout rootLayout;
     private FrameLayout outerRoot;
@@ -296,6 +298,37 @@ public class SettingsActivity extends Activity {
         wifiHint.setPadding(40, 0, 0, 0);
         panelNetwork.addView(wifiHint);
 
+        TextView wifiTimeoutLabel = new TextView(this);
+        wifiTimeoutLabel.setText("WiFi connect timeout (seconds)");
+        wifiTimeoutLabel.setTextColor(0xFF000000);
+        LinearLayout.LayoutParams wifiTimeoutLabelParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        wifiTimeoutLabelParams.topMargin = 12;
+        panelNetwork.addView(wifiTimeoutLabel, wifiTimeoutLabelParams);
+
+        wifiTimeoutInput = new EditText(this);
+        wifiTimeoutInput.setInputType(android.text.InputType.TYPE_CLASS_NUMBER);
+        wifiTimeoutInput.setTextColor(0xFF000000);
+        wifiTimeoutInput.setText(String.valueOf(ApiPrefs.getWifiConnectTimeoutSeconds(this)));
+        LinearLayout.LayoutParams wifiTimeoutInputParams = new LinearLayout.LayoutParams(
+                160, ViewGroup.LayoutParams.WRAP_CONTENT);
+        wifiTimeoutInputParams.topMargin = 4;
+        panelNetwork.addView(wifiTimeoutInput, wifiTimeoutInputParams);
+
+        TextView wifiTimeoutHint = new TextView(this);
+        wifiTimeoutHint.setText("How long to wait for WiFi to connect on wake before "
+                + "giving up. Raise this if your network is slow to join ("
+                + ApiPrefs.MIN_WIFI_CONNECT_TIMEOUT_SECONDS + "\u2013"
+                + ApiPrefs.MAX_WIFI_CONNECT_TIMEOUT_SECONDS + "s, default "
+                + ApiPrefs.DEFAULT_WIFI_CONNECT_TIMEOUT_SECONDS + "s).");
+        wifiTimeoutHint.setTextSize(11);
+        wifiTimeoutHint.setTextColor(0xFF888888);
+        wifiTimeoutHint.setPadding(0, 0, 0, 0);
+        LinearLayout.LayoutParams wifiTimeoutHintParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        wifiTimeoutHintParams.topMargin = 2;
+        panelNetwork.addView(wifiTimeoutHint, wifiTimeoutHintParams);
+
         main.addView(panelNetwork);
 
         // ── Panel: System ────────────────────────────────────────────────────
@@ -543,6 +576,7 @@ public class SettingsActivity extends Activity {
         if (allowHttpCheck != null) allowHttpCheck.setChecked(ApiPrefs.isAllowHttp(this));
         if (allowSelfSignedCheck != null) allowSelfSignedCheck.setChecked(ApiPrefs.isAllowSelfSignedCerts(this));
         if (autoDisableWifiCheck != null) autoDisableWifiCheck.setChecked(ApiPrefs.isAutoDisableWifi(this));
+        if (wifiTimeoutInput != null) wifiTimeoutInput.setText(String.valueOf(ApiPrefs.getWifiConnectTimeoutSeconds(this)));
         if (wifiStatusView != null) wifiStatusView.setText(getWifiStatusText());
     }
 
@@ -563,5 +597,15 @@ public class SettingsActivity extends Activity {
         if (allowHttpCheck != null) ApiPrefs.setAllowHttp(this, allowHttpCheck.isChecked());
         if (allowSelfSignedCheck != null) ApiPrefs.setAllowSelfSignedCerts(this, allowSelfSignedCheck.isChecked());
         if (autoDisableWifiCheck != null) ApiPrefs.setAutoDisableWifi(this, autoDisableWifiCheck.isChecked());
+        if (wifiTimeoutInput != null) {
+            String raw = wifiTimeoutInput.getText() != null ? wifiTimeoutInput.getText().toString().trim() : "";
+            if (raw.length() > 0) {
+                try {
+                    ApiPrefs.setWifiConnectTimeoutSeconds(this, Integer.parseInt(raw));
+                } catch (NumberFormatException nfe) {
+                    // Leave the existing value untouched on bad input.
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #45. That PR shipped the core WiFi-reconnect fix but I left out the configurable-timeout half of the change (the `ApiPrefs` pref + the Settings UI never made it into the commit), so the v0.15.0 CHANGELOG entry was only half true. This adds it.

Implements egtung's request in #44 to make the 5s associate timeout user-configurable.

### Changes

**`ApiPrefs.java`**
- New `wifi_connect_timeout_seconds` pref with getter/setter, default **5s** (preserves existing behavior), clamped to 5–120s

**`SettingsActivity.java`**
- New "WiFi connect timeout (seconds)" numeric field in **Settings → Network**, with a hint explaining when to raise it

**`DisplayActivity.java`**
- `waitForWifiThenFetch()` now uses the configured value as the base association wait, taking `max()` with the cold-radio window when the radio is still powering on
- Removed the now-unused `CONNECTIVITY_MAX_WAIT_MS` constant

## Testing

Built with Ant in the devcontainer (compiles clean on top of merged `main`).
