### PR TITLE
Fix: restore shared_prefs ownership after writing prefs as root

### DIFF
--- a/tools/nook-adb.sh
+++ b/tools/nook-adb.sh
@@ -358,6 +358,28 @@ get_settings() {
   adb_target shell cat "${PREFS_FILE}"
 }
 
+# Writing PREFS_FILE over adb runs as root (uid 0 on NST), which leaves
+# shared_prefs/ owned by root. The app runs as its own uid and then cannot
+# persist SharedPreferences writes (the dir isn't writable by the app), so
+# in-app settings changes silently revert on the next app restart. Restore
+# ownership/permissions to the app uid after any root write.
+fix_prefs_owner() {
+  local prefs_dir="/data/data/${APP_PKG}/shared_prefs"
+  local owner
+  owner="$(adb_target shell "ls -l /data/data" 2>/dev/null \
+            | tr -d '\r' | awk -v p="${APP_PKG}" '$NF==p {print $3}')"
+  if [[ -z "${owner}" ]]; then
+    echo "warning: could not determine app uid; prefs left owned by root" \
+         "(the app may not persist settings changes)" >&2
+    return 0
+  fi
+  # NST toolbox chown: no -R, '.' separator.
+  adb_target shell chown "${owner}.${owner}" "${prefs_dir}"  2>/dev/null || true
+  adb_target shell chown "${owner}.${owner}" "${PREFS_FILE}" 2>/dev/null || true
+  adb_target shell chmod 771 "${prefs_dir}"  2>/dev/null || true
+  adb_target shell chmod 660 "${PREFS_FILE}" 2>/dev/null || true
+}
+
 set_settings() {
   local src="${1:-}"
   [[ -n "${src}" ]] || die "set-settings requires --file /path/to/prefs.xml"
@@ -366,6 +388,7 @@ set_settings() {
   local tmp="/data/local/tmp/trmnl_prefs.xml"
   adb_target push "${src}" "${tmp}" >/dev/null
   adb_target shell "cat \"${tmp}\" > \"${PREFS_FILE}\""
+  fix_prefs_owner
   echo "Settings written."
   get_settings
 }
@@ -415,6 +438,7 @@ EOF
 
   adb_target push "${tmp_local}" "${tmp_remote}" >/dev/null
   adb_target shell "cat \"${tmp_remote}\" > \"${PREFS_FILE}\""
+  fix_prefs_owner
   rm -f "${tmp_local}"
   echo "Settings updated."
   get_settings


### PR DESCRIPTION
## Problem
`set-settings`/`set-setting` write `trmnl_prefs.xml` via a root adb shell (uid 0 on the NST), which leaves `/data/data/<pkg>/shared_prefs/` (directory **and** file) owned by `root:root`. The app runs as its own uid (e.g. `app_1`), which has no **write** permission on the root-owned directory (mode `775`).

Because `SharedPreferences.commit()` persists by creating a temp/backup file and renaming it inside `shared_prefs/`, the disk write fails — but the in-memory map still updates. So:

- Custom settings (e.g. `api_base_url`, `allow_http`) appear to work for as long as the app process lives.
- The on-disk file never changes (mtime frozen at provisioning time).
- On the next app restart (reboot / low-memory kill / relaunch) the stale file reloads and the settings revert.

This is the "settings revert every 24–96h" report in #41.

### Diagnosis signature
Broken (root-owned, app can't persist):
```
drwxrwxr-x root  root   shared_prefs
-rw-rw-rw- root  root   trmnl_prefs.xml      # mode 666, stale mtime
```
Healthy (app wrote it itself):
```
-rw-rw---- app_1 app_1  trmnl_prefs.xml      # mode 660, current mtime
```

## Fix
Add `fix_prefs_owner()` and call it after each root write in `set_settings` and `set_kv_settings`. It restores ownership to the app uid (derived from the owner of `/data/data/<pkg>` rather than hard-coding `app_1`, since that name depends on install order) and the conventional prefs permissions (`771` dir, `660` file).

Notes:
- NST toolbox `chown` has no `-R` and uses a `.` separator (`uid.gid`), not `:`.
- The **WebUSB setup tool** (nooks.bpmct.net) is the more common provisioning path and likely root-owns the file the same way — worth a matching fix there.

## Testing
Verified on a live device: after manually applying the equivalent `chown app_1.app_1` and re-entering settings via the app UI, the custom `api_base_url` + `allow_http` persisted across a full reboot (file owned by `app_1`, mode `660`, fresh mtime). With this patch the same restoration happens automatically after every `set-settings`/`set-setting`.

Fixes #41